### PR TITLE
スタイルを追加&微修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,9 @@ WebAssembly版のTacSimulatorを実装する
 ├── server
 │   ├── WebAPI側の実装
 │   ...
-
+├── test
+│   ├── パフォーマンス比較用のクイックソートのコードとディスクイメージ
+│   ...
+├── performance_measurement
+│   ├── 実機の計測用コード
 ```

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,7 +18,7 @@ trunk = "0.18.4"
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.38"
 wasm-logger = "0.2.0"
-web-sys = { version = "0.3.64", features = ["HtmlInputElement", "Document", "console", "HtmlImageElement", "CanvasRenderingContext2d", "HtmlCanvasElement"] }
+web-sys = { version = "0.3.64", features = ["HtmlInputElement", "Document", "console", "HtmlImageElement", "CanvasRenderingContext2d", "HtmlCanvasElement", "DomRect"] }
 yew = { version = "0.21.0", features = ["csr"] }
 yew-hooks = "0.3.0"
 

--- a/app/src/core/console/console.rs
+++ b/app/src/core/console/console.rs
@@ -196,7 +196,8 @@ impl Component for Console {
                 true
             }
             Msg::Clicked((x, y)) => {
-                if self.on_click(x, y) {
+                let rect = self.ctx.cast::<HtmlCanvasElement>().unwrap().get_bounding_client_rect();
+                if self.on_click((x as f64 - rect.left()) as i32, (y as f64 - rect.top()) as i32)  {
                     self.update();
                     return true;
                 }

--- a/app/src/core/io/device/logger.rs
+++ b/app/src/core/io/device/logger.rs
@@ -1,10 +1,9 @@
 use crate::core::interrupt::interrupt::Interrupt;
 use crate::core::interrupt::intr_controller::IntrController;
 use crate::core::traits::io::device::io_serial::IIOSerial;
-use gloo::console;
 use std::cell::RefCell;
 use std::rc::Rc;
-use web_sys::HtmlInputElement;
+use web_sys::{HtmlInputElement, HtmlTextAreaElement};
 use yew::NodeRef;
 
 #[derive(PartialEq, Clone)]
@@ -13,15 +12,21 @@ pub struct Logger {
     buf: String,
     intr_sig: Rc<RefCell<IntrController>>,
     logger_switch: NodeRef,
+    logger_textarea: NodeRef,
 }
 
 impl Logger {
-    pub fn new(intr_sig: Rc<RefCell<IntrController>>, logger_switch: NodeRef) -> Self {
+    pub fn new(
+        intr_sig: Rc<RefCell<IntrController>>,
+        logger_switch: NodeRef,
+        logger_textarea: NodeRef,
+    ) -> Self {
         Self {
             sendable_intr_flag: false,
             buf: String::new(),
             intr_sig,
             logger_switch,
+            logger_textarea,
         }
     }
 
@@ -49,7 +54,9 @@ impl IIOSerial for Logger {
                 .replace('\r', "");
             self.buf = self.buf.clone() + &ch;
             if ch.eq("\n") {
-                console::log!(&format!("{}", self.buf.clone()));
+                let logger_textarea = self.logger_textarea.cast::<HtmlTextAreaElement>().unwrap();
+                logger_textarea.set_value(&(logger_textarea.value() + &self.buf.clone()));
+                logger_textarea.set_scroll_top(logger_textarea.scroll_height());
                 self.buf = String::new();
             }
         }

--- a/app/src/core/tac.rs
+++ b/app/src/core/tac.rs
@@ -63,6 +63,7 @@ impl Tac {
         components: Rc<RefCell<Components>>,
         terminal: NodeRef,
         input: NodeRef,
+        logger_textarea: NodeRef,
     ) -> Self {
         let intr_host = IntrController::new();
         let intr_host_clone = Rc::new(RefCell::new(intr_host));
@@ -74,6 +75,7 @@ impl Tac {
         let logger = Rc::new(RefCell::new(Logger::new(
             Rc::clone(&intr_host_clone),
             input.clone(),
+            logger_textarea.clone(),
         )));
         let timers = Rc::new(RefCell::new(Timer::new(Rc::clone(&intr_host_clone))));
         let terminal_io = Rc::new(RefCell::new(TerminalIO::new(

--- a/app/src/core/tac_wrap.rs
+++ b/app/src/core/tac_wrap.rs
@@ -80,16 +80,25 @@ impl Component for TacWrap {
         html! {
             <>
                 <ContextProvider<Rc<RefCell<Tac>>> context={Rc::clone(tac)} >
-                    <section class="layout">
-                        <div class="console-area">
+                    <div class="console_area">
+                        <div>
                             <Console state={Rc::clone(&self.console_state)} component={Rc::clone(&self.components)} />
-                            <input ref={&self.input.clone()} type="checkbox" id={"logger_switch"}/>
-                            <textarea ref={&self.logger.clone()} readonly=true id={"logger"}></textarea>
                         </div>
-                        <div class="terminal-area">
-                            <textarea ref={&self.terminal.clone()} readonly=true onkeydown={on_keydown} id={"terminal"}></textarea>
+                    </div>
+                    <div class={"logger_area"}>
+                        <div class={"textarea_header logger_header"}>{"Logger"}</div>
+                        <textarea ref={&self.logger.clone()} readonly=true class={"logger"}></textarea>
+                    </div>
+                    <div class={"logger_switch_area"}>
+                        <div class={"logger_switch_wrap"}>
+                            <input ref={&self.input.clone()} type="checkbox" class={"logger_switch"} name={"logger_switch"}/>
+                            <label for={"logger_switch"}></label>
                         </div>
-                    </section>
+                    </div>
+                    <div class="terminal_area">
+                        <div class={"textarea_header"}>{"Terminal"}</div>
+                        <textarea ref={&self.terminal.clone()} readonly=true onkeydown={on_keydown} class={"terminal"}></textarea>
+                    </div>
                 </ContextProvider<Rc<RefCell<Tac>>>>
             </>
         }

--- a/app/src/core/tac_wrap.rs
+++ b/app/src/core/tac_wrap.rs
@@ -19,6 +19,7 @@ pub struct TacWrap {
     tac: Rc<RefCell<Tac>>,
     terminal: NodeRef,
     input: NodeRef,
+    logger: NodeRef,
 }
 
 impl TacWrap {
@@ -35,6 +36,7 @@ impl TacWrap {
         let components = Rc::new(RefCell::new(Components::new()));
         let terminal = NodeRef::default();
         let input = NodeRef::default();
+        let logger = NodeRef::default();
         let tac = Rc::new(RefCell::new(Tac::new(
             dmg,
             Rc::clone(&memory),
@@ -44,6 +46,7 @@ impl TacWrap {
             Rc::clone(&components),
             terminal.clone(),
             input.clone(),
+            logger.clone(),
         )));
         Self {
             memory,
@@ -54,6 +57,7 @@ impl TacWrap {
             tac,
             terminal,
             input,
+            logger,
         }
     }
 }
@@ -79,10 +83,11 @@ impl Component for TacWrap {
                     <section class="layout">
                         <div class="console-area">
                             <Console state={Rc::clone(&self.console_state)} component={Rc::clone(&self.components)} />
-                            <input ref={&self.input.clone()} type="checkbox"/>
+                            <input ref={&self.input.clone()} type="checkbox" id={"logger_switch"}/>
+                            <textarea ref={&self.logger.clone()} readonly=true id={"logger"}></textarea>
                         </div>
                         <div class="terminal-area">
-                            <textarea ref={&self.terminal.clone()} readonly=true onkeydown={on_keydown}></textarea>
+                            <textarea ref={&self.terminal.clone()} readonly=true onkeydown={on_keydown} id={"terminal"}></textarea>
                         </div>
                     </section>
                 </ContextProvider<Rc<RefCell<Tac>>>>

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -75,7 +75,8 @@ fn simulator() -> Html {
         })
     };
     return html! {
-        <>
+        <main class={"layout"}>
+
             {
                 if dmg.loading {
                     html! {
@@ -93,7 +94,6 @@ fn simulator() -> Html {
                     for (i, data) in data.get_data().iter().enumerate() {
                         dmg_data.borrow_mut().push(*data);
                     }
-                    gloo::console::log!(&format!("data {} dmg {}", dmg_data.borrow().len(), data.get_data().len()));
                     html! {
                         <>
                             <Tac dmg={Rc::clone(&dmg_data)}/>
@@ -101,7 +101,7 @@ fn simulator() -> Html {
                     }
                 } else {
                     html! {
-                        <p>{"Loading ..."}</p>
+                        <></>
                     }
                 }
             }
@@ -119,26 +119,28 @@ fn simulator() -> Html {
         {
             if !(*is_login).clone() {
                 html!{
-                    <form>
-                        <div>
+                    <form class={"login_form"}>
+                        <div class={"form_el_wrap"}>
                             <label for={"user_name"}>{"ユーザー名"}</label>
-                            <input type={"text"} name={"user_name"} id={"user_name"} required={true} oninput={user_name_on_input} value={(*user_name).clone()} />
+                            <input type={"text"} name={"user_name"} id={"user_name"} required={true} oninput={user_name_on_input} value={(*user_name).clone()} placeholder={"UserName"} />
                         </div>
-                        <div>
+                        <div class={"form_el_wrap"}>
                             <label for={"user_password"}>{"パスワード"}</label>
-                            <input type={"text"} name={"user_password"} id={"user_password"} required={true} oninput={password_on_input} value={(*password).clone()}/>
+                            <input type={"password"} name={"user_password"} id={"user_password"} required={true} oninput={password_on_input} value={(*password).clone()} placeholder={"PASSWORD"}/>
                         </div>
 
-                        <button onclick={get_dmg} disabled={dmg.loading}>{"ログイン"}</button>
+                        <button onclick={get_dmg} disabled={dmg.loading} class={"login_btn"}>{"ログイン"}</button>
                     </form>
                 }
             } else {
                 html! {
-                    <button onclick={save_btn_onclick}>{"保存"}</button>
+                    <div class={"save_btn_area"}>
+                        <button onclick={save_btn_onclick} class={"save_btn"}>{"保存"}</button>
+                    </div>
                 }
             }
         }
-        </>
+        </main>
     };
 }
 fn main() {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,16 +1,17 @@
 use crate::core::tac_wrap::TacWrap as Tac;
-use crate::util::fetch::{fetch_and_convert_into_vector, get_dmg_path, Dmg, FetchError, update_dmg};
+use crate::util::fetch::{
+    fetch_and_convert_into_vector, get_dmg_path, update_dmg, Dmg, FetchError,
+};
 use app::consts::BASE_URL;
 use std::cell::RefCell;
 use std::rc::Rc;
 use web_sys::InputEvent;
-use yew::{function_component, html, use_state, Callback, Html};
 use yew::html::onclick::Event;
+use yew::{function_component, html, use_state, Callback, Html};
 use yew_hooks::{use_async, UseAsyncHandle};
 
 mod core;
 mod util;
-
 
 #[function_component(Simulator)]
 fn simulator() -> Html {
@@ -53,7 +54,7 @@ fn simulator() -> Html {
             fetch_and_convert_into_vector(BASE_URL.to_string() + &format!("dmg/{}", path)).await
         }
     });
-    let onclick = {
+    let get_dmg = {
         let dmg = dmg.clone();
         Callback::from(move |_| {
             dmg.run();
@@ -128,7 +129,7 @@ fn simulator() -> Html {
                             <input type={"text"} name={"user_password"} id={"user_password"} required={true} oninput={password_on_input} value={(*password).clone()}/>
                         </div>
 
-                        <button {onclick} disabled={dmg.loading}>{"ログイン"}</button>
+                        <button onclick={get_dmg} disabled={dmg.loading}>{"ログイン"}</button>
                     </form>
                 }
             } else {

--- a/app/src/util/fetch.rs
+++ b/app/src/util/fetch.rs
@@ -15,7 +15,7 @@ impl Dmg {
     pub fn new() -> Self {
         Self {
             name: "default".to_string(),
-            data: vec![]
+            data: vec![],
         }
     }
     pub fn get_data(&self) -> Vec<u8> {
@@ -83,12 +83,10 @@ pub async fn fetch_and_convert_into_vector(url: String) -> Result<Dmg, FetchErro
 }
 
 pub async fn update_dmg(name: String, data: Vec<u8>) -> Result<(), FetchError> {
-    let dmg = Dmg {
-        name,
-        data
-    };
+    let dmg = Dmg { name, data };
     let client = reqwest::Client::new();
-    let res = client.post(BASE_URL.to_string() + "dmg/update")
+    let res = client
+        .post(BASE_URL.to_string() + "dmg/update")
         .json(&dmg)
         .send()
         .await

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,23 +1,83 @@
-.layout {
-    width: 1200px;
-    height: 100%;
-    display: grid;
-    grid: 'console-area terminal-area' 1fr / 600px auto;
-    gap: 0;
+* {
+    margin: 0;
 }
 
-.console-area {
-    grid-area: console-area;
-}
-
-.terminal-area {
-    grid-area: terminal-area;
-}
-
-.terminal-area textarea {
-    min-width: 600px;
-    width: 100vw;
+body {
+    background-color: #f0f8ff;
+    margin: 0 auto;
+    overflow: hidden;
+    max-width: 1200px;
+    min-width: 400px;
     height: 100vh;
+}
+
+.layout {
+    width: 100%;
+    height: 100vh;
+    display: grid;
+    grid-template:
+        'console_area       console_area  terminal_area' 400px
+        'logger_area        logger_area   terminal_area' 500px
+        'logger_switch_area save_btn_area termional_area' auto / 1fr 1fr auto;
+    gap: 8px;
+    padding: 8px;
+    margin-bottom: 8px;
+}
+
+.console_area {
+    grid-area: console_area;
+}
+
+.terminal_area {
+    grid-area: terminal_area;
+}
+
+.logger_area {
+    grid-area: logger_area;
+}
+
+.logger_switch_area {
+    grid-area: logger_switch_area;
+}
+
+.save_btn_area {
+    grid-area: save_btn_area;
+}
+
+.textarea_header {
+    background-color: #323234;
+    text-align: center;
+    font-weight: bold;
+    padding: 4px;
+    color: #c0c0c0;
+    cursor: pointer;
+    border-top-right-radius: 10px;
+    border-top-left-radius: 10px;
+    user-select: none;
+    font-family: sans-serif;
+}
+
+.logger_header {
+    min-width: 500px;
+}
+
+.logger {
+    width: calc(100% - 4px);
+    border: none;
+    resize: none;
+    background-color: black;
+    color: white;
+    font-family: 'courier new', Futura, Helvetica, '游ゴシック', 'メイリオ', Osaka;
+    font-size: 10px;
+    line-height: 1.2em;
+    height: 400px;
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+}
+
+.terminal {
+    min-width: 600px;
+    height: calc(100% - 16px);
     border: none;
     resize: none;
     background-color: black;
@@ -25,4 +85,44 @@
     font-family: 'courier new', Futura, Helvetica, '游ゴシック', 'メイリオ', Osaka;
     font-size: 10pt;
     line-height: 1.2em;
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+}
+
+.save_btn {
+    padding: 8px;
+    font-size: 1rem;
+    border: none;
+    color: aliceblue;
+    background-color: #007aff;
+    border-radius: 10px;
+}
+
+
+.login_form {
+    text-align: center;
+}
+
+.form_el_wrap > input {
+    margin-top: 1rem;
+    background: gainsboro;
+    width: 50%;
+    border: none;
+    font-size: 1rem;
+    padding: .3rem;
+    border-radius: 5px;
+    color: gray;
+}
+
+.form_el_wrap > input:nth-child(even) {
+    margin-bottom: 1rem;
+}
+
+.login_btn {
+    padding: 8px;
+    font-size: 1rem;
+    border: none;
+    color: aliceblue;
+    background-color: #007aff;
+    border-radius: 10px;
 }

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users (
+    id serial PRIMARY KEY,
+    name varchar NOT NULL,
+    password varchar NOT NULL
+);

--- a/server/src/application/dmg.rs
+++ b/server/src/application/dmg.rs
@@ -1,5 +1,5 @@
-use axum::extract::DefaultBodyLimit;
 use crate::usecases::dmg::{get_dmg, update_dmg};
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
 

--- a/server/src/application/user.rs
+++ b/server/src/application/user.rs
@@ -1,6 +1,7 @@
 use crate::consts::db_url;
 use crate::entities::user::UserDto;
 use crate::repositories::postgres::PgConn;
+use crate::usecases::dmg::create_new_dmg;
 use crate::usecases::user::user_validation;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -9,7 +10,6 @@ use axum::routing::post;
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use crate::usecases::dmg::create_new_dmg;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ValidationResult {
@@ -74,6 +74,6 @@ pub async fn dmg_name(
                 r#type: ValidationResult::CreateNewUser,
                 dmg_name: Some(created_dmg_path),
             }
-        },
+        }
     };
 }

--- a/server/src/usecases/dmg.rs
+++ b/server/src/usecases/dmg.rs
@@ -1,10 +1,10 @@
-use std::fs::File;
 use crate::consts::{BASE_PATH, TEMPLATE_DMG_PATH};
 use crate::entities::disk_image::Dmg;
 use anyhow::Result;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Json;
+use std::fs::File;
 use std::io::{Read, Write};
 
 fn get_dmg_data(path: String) -> Dmg {
@@ -22,7 +22,11 @@ pub async fn get_dmg(Path(path): Path<String>) -> impl IntoResponse {
 fn update_dmg_data(dmg: Dmg) -> Result<()> {
     let dmg_path = BASE_PATH.to_owned() + &*dmg.get_name() + ".dmg";
     std::fs::remove_file(dmg_path.clone())?;
-    std::fs::copy(&format!("{}template.dmg", BASE_PATH), &format!("{}{}.dmg", BASE_PATH, dmg.get_name())).unwrap();
+    std::fs::copy(
+        &format!("{}template.dmg", BASE_PATH),
+        &format!("{}{}.dmg", BASE_PATH, dmg.get_name()),
+    )
+    .unwrap();
     let mut fd = File::create(dmg_path.clone()).unwrap();
     fd.write_all(dmg.get_data()).unwrap();
     Ok(())


### PR DESCRIPTION
## 修正内容
### センタリングした時にcanvasの位置がずれて`client_x`,`client_y`だとボタンやスイッチの座標がずれてクリックできなくなる問題
[getBoundingClientRect](https://developer.mozilla.org/ja/docs/Web/API/Element/getBoundingClientRect)を用いて解決

https://github.com/TacSimTeam/TacSimulator-WA/blob/9d32abd1f7685154944b9a3bd49ff24268237245/app/src/core/console/console.rs#L199-L201

### c563e2475cfedeb6924c312c66bfe13f11cf86d5 ログをテキストエリアに出力
開発者ツールを開いてTaCのターミナルなどがいじりにくくなるのでロガーもテキストエリアにした
<img width="600" alt="スクリーンショット 2024-01-31 4 56 18" src="https://github.com/TacSimTeam/TacSimulator-WA/assets/57137136/25556a69-08e2-4e20-bd86-a5548d08cfd1">

### d7c1039116b137de5a9db1e8a47b9196691600b5 フォーマット


